### PR TITLE
Change the default GH pages renderer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,10 @@ nav:
     - Lab 1. Using Prompt Engineering: lab-1/README.md
     - Lab 2. Using Generative AI: lab-2/README.md
 
+# Use extended CommonMark renderer
+# Ref to: https://github.com/isaacs/github/issues/1185
+markdown: GFM
+
 ## DO NOT CHANGE BELOW THIS LINE
 
 # Copyright


### PR DESCRIPTION
Change markdown renderer to the renderer used by `github.com`. This is to fix the numbering in
https://github.com/IBM/watsonx-genai-lab/tree/main/docs/lab-2 which is being rendered incorrectly by the default GH pages  kramdown markdown renderer.