### PR TITLE
Fix GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,18 @@ on:
     branches:
       - main
       - master
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: '3.x'
       - run: pip install mkdocs-material "mkdocs-material[imaging]"
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
GH actions now run on Node 16: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/